### PR TITLE
Update OnPageGetSummaryById.php

### DIFF
--- a/src/DFSClient/Models/OnPageApi/OnPageGetSummaryById.php
+++ b/src/DFSClient/Models/OnPageApi/OnPageGetSummaryById.php
@@ -15,7 +15,7 @@ class OnPageGetSummaryById extends AbstractModel
 	
 	/**
 	 * @param string $taskUUID
-	 * @return $this
+	 * @return OnPageGetSummaryById
 	 */
 	public function setTaskId(string $taskUUID)
 	{


### PR DESCRIPTION
PHPDoc does not allow in a @return to return a Variable like $this, the Type of variable should be given not the variable name.