### PR TITLE
update  SearchVolumeLiveEntityMainTasksResult set cpc to double

### DIFF
--- a/src/DFSClient/Entity/Custom/SearchVolumeLiveEntityMainTasksResult.php
+++ b/src/DFSClient/Entity/Custom/SearchVolumeLiveEntityMainTasksResult.php
@@ -27,7 +27,7 @@ class SearchVolumeLiveEntityMainTasksResult
     public $competition = null;
 
     /**
-    * @var null|integer $cpc;
+    * @var null|double $cpc;
     */
     public $cpc = null;
 


### PR DESCRIPTION
In the API query for the search volume of the keywords, you get a wrong value for the CPC property because the API returns a floating point number but the model loads on an integer number